### PR TITLE
Fixed soundlicps not playing when the answer was inputed by hitting enter

### DIFF
--- a/kaniwani_audio.user.js
+++ b/kaniwani_audio.user.js
@@ -62,7 +62,7 @@
         });
         kwa.detailKanjiChanged();
         kwa._answerPanel = document.getElementById('answerPanel');
-        kwa.observeDOM(kwa._detailKanji, function() {
+        kwa.observeDOM(kwa._answerPanel, function() {
             kwa.answerPanelChanged();
         });
     };


### PR DESCRIPTION
Line 65 was "kwa.observeDOM(kwa._detailKanji, function() {", now is "kwa.observeDOM(kwa._answerPanel, function() {".

Tiny mistake in otherwise perfect code! Should work now but please try it yourself if you can first!